### PR TITLE
:memo: self closing tags don't work in angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ The component can be used in an Angular view using the react-component directive
 
 The reactDirective factory, in contrast to the reactComponent directive, is meant to create specific directives corresponding to React components. In the background, this actually creates and sets up directives specifically bound to the specified React component.
 
-If, for example, you wanted to use the same React component in multiple places, you'd have to specify &lt;react-component name="yourComponent" props="props" /&gt; repeatedly, but if you used reactDirective factory, you could create a yourComponent directive and simply use that everywhere.
+If, for example, you wanted to use the same React component in multiple places, you'd have to specify `<react-component name="yourComponent" props="props"></react-component>` repeatedly, but if you used reactDirective factory, you could create a `<your-component></your-component>` directive and simply use that everywhere.
 
 The service takes the React component as the argument.
 
 ```javascript
-app.directive('hello', function(reactDirective) {
+app.directive('helloComponent', function(reactDirective) {
   return reactDirective(HelloComponent);
 });
 ```
@@ -115,7 +115,7 @@ app.directive('hello', function(reactDirective) {
 Alternatively you can provide the name of the component
 
 ```javascript
-app.directive('hello', function(reactDirective) {
+app.directive('helloComponent', function(reactDirective) {
   return reactDirective('HelloComponent');
 });
 ```
@@ -125,7 +125,7 @@ This creates a directive that can be used like this:
 ```html
 <body ng-app="app">
   <div ng-controller="helloController">
-    <hello fname="person.fname" lname="person.lname" watch-depth="reference"/>
+    <hello-component fname="person.fname" lname="person.lname" watch-depth="reference"></hello-component>
   </div>
 </body>
 ```


### PR DESCRIPTION
This is actually because angular uses the DOM and the DOM does not appreciate these